### PR TITLE
Fix: NinjectInstanceProvider.ReleaseInstance() should properly dispose service  instances...

### DIFF
--- a/src/Ninject.Extensions.Wcf/NinjectInstanceProvider.cs
+++ b/src/Ninject.Extensions.Wcf/NinjectInstanceProvider.cs
@@ -86,6 +86,7 @@ namespace Ninject.Extensions.Wcf
         /// </param>
         public void ReleaseInstance( InstanceContext instanceContext, object instance )
         {
+            KernelContainer.Kernel.Release(instance);
         }
 
         #endregion


### PR DESCRIPTION
Calling KernelContainer.Kernel.Release(instance) should do the trick.

 --larsw
