### PR TITLE
Fix issue #36 in nuspec

### DIFF
--- a/nuget/Ninject.Extensions.Wcf.nuspec
+++ b/nuget/Ninject.Extensions.Wcf.nuspec
@@ -19,7 +19,8 @@
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System.Data.Services" />
       <frameworkAssembly assemblyName="System.ServiceModel" />
-      <frameworkAssembly assemblyName="System.ServiceModel.Activation" />
+      <frameworkAssembly assemblyName="System.ServiceModel.Activation" targetFramework="net40" />
+	  <frameworkAssembly assemblyName="System.ServiceModel.Activation" targetFramework="net45" />
       <frameworkAssembly assemblyName="System.ServiceModel.Web" />
     </frameworkAssemblies>
   </metadata>


### PR DESCRIPTION
System.ServiceModel.Activation framework assembly dependency only
applies to net40 and net45.
Fixes issue #36.